### PR TITLE
Resolved bento warnings

### DIFF
--- a/measure
+++ b/measure
@@ -264,7 +264,7 @@ class SignalFx(Measure):
     def _run_command(self, cmd, tout=None, pre=True):
         cmd_type = 'Pre-command' if pre else 'Post-command'
         res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            shell=True, timeout=tout, executable='/bin/bash')
+            shell=True, timeout=tout, executable='/bin/bash') # nosec
         msg = "cmd '{}', exit code {}, stdout {}, stderr {}".format(cmd,
             res.returncode, res.stdout, res.stderr)
         assert res.returncode == 0, '{} failed:  {}'.format(cmd_type, msg)
@@ -272,9 +272,11 @@ class SignalFx(Measure):
 
     # helper:  run a Bash shell command with stdout/stderr directed to /dev/null
     # and return the popen object
+    # note:  if cmd is a string, this supports shell pipes, environment variable
+    # expansion, etc.  The burden of safety is entirely on the user.
     def _run_command_async(self, cmd):
         proc = subprocess.Popen(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL, shell=True, executable='/bin/bash',
+            stderr=subprocess.DEVNULL, shell=True, executable='/bin/bash', # nosec
             preexec_fn=os.setpgrp)
         self._nfy('Pre-command async:  {}'.format(cmd))
         return proc
@@ -285,7 +287,7 @@ class SignalFx(Measure):
         # load YAML config file (raise any unhandled exception)
         try:
             fo = open(CFG_FPATH)
-            desc = yaml.load(fo)
+            desc = yaml.safe_load(fo)
         except IOError as e:
             raise Exception('Cannot read configuration from {}:  {}'.format(
                 CFG_FPATH, e.strerror))
@@ -307,11 +309,11 @@ class SignalFx(Measure):
         # parse descriptor:  metrics
         metrics = sfx.get('metrics',{})
         assert isinstance(metrics, dict) and len(metrics) > 0, \
-            'No metrics config in {}'.format(CFG_PATH)
+            'No metrics config in {}'.format(CFG_FPATH)
         for metric_name, metric in metrics.items():
             assert 'flow_program' in metric, \
                 'No flow_program configured for metric {} in {}'.format(
-                metric_name, CFG_PATH)
+                metric_name, CFG_FPATH)
             metric['flow_immediate'] = metric.get('flow_immediate',
                 DFLT_FLOW_IMMEDIATE)
             metric['flow_resolution'] = metric.get('flow_resolution',
@@ -320,10 +322,10 @@ class SignalFx(Measure):
             metric['space_aggr'] = metric.get('space_aggr', DFLT_SPACE_AGGR)
             assert metric['time_aggr'] in AGGR_OPERATORS, \
                 'Unknown time_aggr {} for metric {} in {}'.format(
-                metric['time_aggr'], metric_name, CFG_PATH)
+                metric['time_aggr'], metric_name, CFG_FPATH)
             assert metric['space_aggr'] in AGGR_OPERATORS, \
                 'Unknown space_aggr {} for metric {} in {}'.format(
-                metric['space_aggr'], metric_name, CFG_PATH)
+                metric['space_aggr'], metric_name, CFG_FPATH)
         self.cfg['metrics'] = metrics
 
     # helper:  print a msg to servo stderr (debug log) and log to the Optune


### PR DESCRIPTION
Bento Output:

```
bandit subprocess-popen-with-shell-equals-true https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html                                                                          
     > measure:267                                                                    
     ╷                                                                                
  267│   res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,    
  268│       shell=True, timeout=tout, executable='/bin/bash')
     ╵
     = subprocess call with shell=True identified, security issue.

bandit subprocess-popen-with-shell-equals-true https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
     > measure:277
     ╷
  277│   proc = subprocess.Popen(cmd, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
  278│       stderr=subprocess.DEVNULL, shell=True, executable='/bin/bash',
  279│       preexec_fn=os.setpgrp)
     ╵
     = subprocess call with shell=True identified, security issue.

bandit yaml-load https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html
     > measure:288
     ╷
  288│   desc = yaml.load(fo)
     ╵
     = Use of unsafe yaml load. Allows instantiation of arbitrary objects.
       Consider yaml.safe_load().

flake8 undefined-name https://lintlyci.github.io/Flake8Rules/rules/F821.html
     > measure:310
     ╷
  310│   'No metrics config in {}'.format(CFG_PATH)
     ╵
     = undefined name 'CFG_PATH'

flake8 undefined-name https://lintlyci.github.io/Flake8Rules/rules/F821.html
     > measure:314
     ╷
  314│   metric_name, CFG_PATH)
     ╵
     = undefined name 'CFG_PATH'

flake8 undefined-name https://lintlyci.github.io/Flake8Rules/rules/F821.html
     > measure:323
     ╷
  323│   metric['time_aggr'], metric_name, CFG_PATH)
     ╵
     = undefined name 'CFG_PATH'

flake8 undefined-name https://lintlyci.github.io/Flake8Rules/rules/F821.html
     > measure:326
     ╷
  326│   metric['space_aggr'], metric_name, CFG_PATH)
     ╵
     = undefined name 'CFG_PATH'
```